### PR TITLE
build: Add release workflow 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: release
+
+on:
+  workflow_dispatch:
+    
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # fetch full history
+        filter: tree:0
+
+    - name: Create release branch.
+      run: |
+        make create-release-branch
+
+    - name: Create release notes.
+      run: |
+        make create-release-notes
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git add CHANGELOG
+        git commit -m "chore: release notes"
+        git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 # Binaries
 bin/*
-!bin/get_version.sh
+!bin/*.sh

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,19 @@ docker-build: ## Build docker image.
 docker-push: ## Push docker image.
 	docker push ${IMG}
 
+##@ Release
+.PHONY: generate-latest-tag
+generate-latest-tag: ## Generates the latest tag.
+	./bin/bump_tag.sh
+
+.PHONY: create-release-branch 
+create-release-branch: generate-latest-tag ## Creates a release branch.
+	./bin/release.sh
+
+.PHONY: create-release-notes
+create-release-notes:  ## Creates release notes.
+	./bin/generate_release_notes.sh
+
 ##@ Build Dependencies
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin

--- a/bin/bump_tag.sh
+++ b/bin/bump_tag.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Pushes a new tag as needed to the remote.
+# If the latest tag is associated with the current commit, no action is taken.
+# If the latest tag is associated with a previous commit:
+#   - Retrieve all commits between the current commit and commit associated with the latest tag.
+#       - If any commit contains the string "BREAKING CHANGE"; increment the major, reset the minor and patch.
+#       - If any commit contains the string "feat"; increment the minor and reset the patch version.
+#       - if any commit contains the string "fix"; increment the patch version.
+#   - The above 3 actions are mutually exclusive with one another.
+#   - The new tag (if there is one) is then pushed to the remote.
+
+# Do nothing if the latest tag corresponds to the current commit.
+if git describe --tags --exact-match &>/dev/null; then
+    echo "Latest commit is tagged."
+    exit 0
+fi
+
+
+latest_tag=$(git describe --tags --abbrev=0)
+latest_tag_commit=$(git rev-list -n 1 "${latest_tag}")
+
+
+major_minor_patch=$(echo "${latest_tag}" | cut -c2-)
+major=$(echo "${major_minor_patch}" | cut --delimiter=. --fields=1)
+minor=$(echo "${major_minor_patch}" | cut --delimiter=. --fields=2)
+patch=$(echo "${major_minor_patch}" | cut --delimiter=. --fields=3)
+
+
+# Retrieve all the commits between the current commit and the commit corresponding to the latest tag.
+# The major, minor or patch version will be incremented based on the commit titles.
+commits=$(git log --oneline --no-decorate --pretty=format:"%s" "${latest_tag_commit}"..HEAD)
+if echo "$commits" | grep -E "^BREAKING(.*):" &>/dev/null; then
+    ((major++))
+    minor=0
+    patch=0
+elif echo "$commits" | grep -E "^feat(.*):" &>/dev/null; then
+    ((minor++))
+    patch=0
+elif echo "$commits" | grep -E "^fix(.*):" &>/dev/null; then
+    ((patch++))
+fi
+
+
+new_tag="v${major}.${minor}.${patch}"
+if [[ "$latest_tag" == "$new_tag" ]]; then
+    echo "Generated tag is the same as latest."
+    exit 0
+fi
+
+echo "Pushing new tag: ${new_tag}"
+git tag "${new_tag}"
+git push origin "${new_tag}"

--- a/bin/generate_release_notes.sh
+++ b/bin/generate_release_notes.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+readonly GIT_ROOT
+
+PULL_REQUEST_BASE="https:\/\/github.com\/AyCarlito\/kube-visualization\/pull"
+readonly PULL_REQUEST_BASE
+
+latest_tag=$(git describe --tags --abbrev=0)
+latest_tag_commit=$(git rev-list -n 1 "${latest_tag}")
+previous_tag=$(git describe --abbrev=0 --tags "$(git rev-list --tags --skip=1 --max-count=1)")
+previous_tag_commit=$(git rev-list -n 1 "${previous_tag}")
+
+changelog="${GIT_ROOT}/CHANGELOG/CHANGELOG-$latest_tag.md"
+readonly changelog
+
+# Retrieve all the commits between the previous tag and latest tag.
+commits=$(git log --oneline --no-decorate --pretty=format:"%s" "${previous_tag_commit}".."${latest_tag_commit}")
+
+breaking_changes=$(echo "${commits}" | grep -E "^BREAKING(.*):" | awk -F':' '{print "-" $2}')
+features=$(echo "${commits}" | grep -E "^feat(.*):" | awk -F':' '{print "-" $2}')
+fixes=$(echo "${commits}" | grep -E "^fix(.*):" | awk -F':' '{print "-" $2}')
+
+mkdir -p CHANGELOG
+echo "# ${latest_tag}" > "${changelog}"
+
+if [ -n "${breaking_changes}" ]; then
+    printf "\nBREAKING CHANGES:\n\n%s\n" "${breaking_changes}" >> "${changelog}"
+fi
+
+if [ -n "${features}" ]; then
+    printf "\nFeatures:\n\n%s\n" "${features}" >> "${changelog}"
+fi
+
+if [ -n "${fixes}" ]; then
+    printf "\nFixes:\n\n%s\n" "${fixes}" >> "${changelog}"
+fi
+
+# Consider the pattern (#19), we replace it with "[#19](https://github.com/AyCarlito/kube-visualization/pull/19)".
+sed -i -E "s|(#([0-9]+))|[#\2](${PULL_REQUEST_BASE}/\2)|g" "${changelog}"

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Creates a release branch in the repository using the latest tag.
+
+latest_tag=$(git describe --tags --abbrev=0)
+release_branch="releases/release-${latest_tag}"
+
+git checkout -b "${release_branch}"
+git push --set-upstream origin "${release_branch}"


### PR DESCRIPTION
This PR:

- Add a release workflow that:
    - Generates and pushes a new tag to the repository.
    - Creates a release branch using the new tag.
    - Generates release notes based on the commits between the latest tag and previous tag. These are pushed to the release branch during the release workflow in a file named "CHANGELOG/CHANGELOG-<tag>.md".