### PR TITLE
fix: Add alias for pointer types and non v1 packages

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -157,7 +157,8 @@ func (g *Generator) dump(v reflect.Value) {
 		}
 		g.out.Write(openSquareBracketBytes)
 		g.out.Write(closeSquareBracketBytes)
-		g.out.Write([]byte(v.Elem().Type().String()))
+		g.packages[importWithAlias(v.Type().Elem().PkgPath())] = struct{}{}
+		g.out.Write([]byte(strings.TrimPrefix(typeWithAlias(v, v.Type().Elem().PkgPath()), "*")))
 		g.out.Write(openBraceBytes)
 		g.dump(v.Elem())
 		g.out.Write(closeBraceBytes)

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -62,5 +62,5 @@ func typeWithAlias(v reflect.Value, path string) string {
 	}
 	packagePathParts := strings.Split(path, "/")
 	alias := packagePathParts[len(packagePathParts)-2] + packagePathParts[len(packagePathParts)-1]
-	return strings.Replace(v.Type().String(), "v1", alias, -1)
+	return strings.Replace(v.Type().String(), packagePathParts[len(packagePathParts)-1], alias, -1)
 }


### PR DESCRIPTION
This PR:
- Pointer types from Kubernetes packages were missing their alias e.g. the value for `PreemptionPolicy` in `corev1.PodSpec` was being written as `&[]v1.PreemptionPolicy{"Never"}[0],`. It should be `&[]corev1.PreemptionPolicy{"Never"}[0],`
- 